### PR TITLE
Refactor memoize_decorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,11 +14,6 @@ Python 3.7+ async-enabled decorators and tools including
 
     If 'expire' is provided, memoize will only retain return values for up to 'expire' duration.
 
-    If 'pass_unhashable' is True, memoize will not remember calls that are made with parameters
-      that cannot be hashed instead of raising an exception.
-
-    if 'thread_safe' is True, the decorator is guaranteed to be thread safe.
-
     Examples:
 
         - Body will run once for unique input 'bar' and result is cached.
@@ -58,14 +53,6 @@ Python 3.7+ async-enabled decorators and tools including
             foo(1)  # Function not called. Previously-cached result returned.
             sleep(61)
             foo(1)  # Function actually called. Previously-cached result was too old.
-
-        - Thread safety is not enabled by default. It must be explicitly enabled.
-            @memoize(thread_safe=True)
-            def foo(bar) -> Any: ...
-
-            # Concurrent calls from multiple threads are safe. Only one call is generated. The
-            # other nine calls in this example wait for the result.
-            concurrent.futures.Executor.map(foo, [1] * 10)
 
         - Memoize can be explicitly reset through the function's 'memoize' attribute
             @memoize

--- a/atools/memoize_decorator.py
+++ b/atools/memoize_decorator.py
@@ -1,71 +1,255 @@
-from asyncio import Event
+from asyncio import Lock as LockAsync
 from atools.decorator_mixin import DecoratorMixin, Fn
 from collections import deque, ChainMap, OrderedDict
+from dataclasses import dataclass, field, InitVar
 from datetime import timedelta
 import inspect
 from time import time
-from threading import Lock
-from typing import Any, Optional, Tuple, Union
+from threading import Lock as LockSync
+from typing import Any, Optional, Tuple, Type, Union
 
 
-class _Memo:
-    _sync_called: bool = False
-    _sync_return: Any = None
-    _sync_raise: bool = False
-    _async_called: bool = False
-    _async_return: Any = None
-    _async_raise: bool = False
-    _event: Optional[Event] = None
+class _MemoReturnState:
+    called: bool = False
+    raised: bool = False
+    value: Any = ...
 
-    def __init__(
-            self, fn: Fn, expire_time: Optional[float] = None, thread_safe: bool = False
-    ) -> None:
-        self._fn = fn
-        self.expire_time = expire_time
-        self._lock: Optional[Lock] = Lock() if thread_safe is True else None
 
-    def __call__(self, *args, **kwargs):
-        with self:
-            if not self._sync_called:
-                self._sync_called = True
-                try:
-                    self._sync_return = self._fn(*args, **kwargs)
-                except Exception as e:
-                    self._sync_raise = True
-                    self._sync_return = e
+@dataclass(frozen=True)
+class _MemoReturnAsync:
+    fn: Fn
+    _state: _MemoReturnState = field(init=False, default_factory=_MemoReturnState)
 
-        if inspect.iscoroutine(self._sync_return):
-            return self.__async_unwrap()
-        elif self._sync_raise:
-            raise self._sync_return
+    async def __call__(self, *args, **kwargs) -> Any:
+        if not self._state.called:
+            self._state.called = True
+            try:
+                self._state.value = await self.fn(*args, **kwargs)
+            except Exception as e:
+                self._state.raised = True
+                self._state.value = e
+
+        if self._state.raised:
+            raise self._state.value
         else:
-            return self._sync_return
+            return self._state.value
 
-    def __enter__(self) -> None:
-        if self._lock is not None:
-            self._lock.acquire()
+
+@dataclass(frozen=True)
+class _MemoReturnSync:
+    fn: Fn
+    _state: _MemoReturnState = field(init=False, default_factory=_MemoReturnState)
+
+    def __call__(self, *args, **kwargs) -> Any:
+        if not self._state.called:
+            self._state.called = True
+            try:
+                self._state.value = self.fn(*args, **kwargs)
+            except Exception as e:
+                self._state.raised = True
+                self._state.value = e
+
+        if self._state.raised:
+            raise self._state.value
+        else:
+            return self._state.value
+
+
+@dataclass(frozen=True)
+class _MemoAsyncContext:
+    fn: InitVar[Fn]
+
+    _memo_return_async: _MemoReturnAsync = field(init=False)
+    _lock_async: LockAsync = field(init=False, default_factory=lambda: LockAsync())
+
+    def __post_init__(self, fn: Fn) -> None:
+        object.__setattr__(self, '_memo_return_async', _MemoReturnAsync(fn=fn))
+
+    async def __aenter__(self) -> _MemoReturnAsync:
+        async with self._lock_async:
+            return self._memo_return_async
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        pass
+
+
+@dataclass(frozen=True)
+class _MemoSyncContext:
+    fn: InitVar[Fn]
+
+    _memo_return_sync: _MemoReturnSync = field(init=False)
+    _lock_sync: LockSync = field(init=False, default_factory=lambda: LockSync())
+
+    def __post_init__(self, fn: Fn) -> None:
+        object.__setattr__(self, '_memo_return_sync', _MemoReturnSync(fn=fn))
+
+    def __enter__(self) -> _MemoReturnSync:
+        with self._lock_sync:
+            return self._memo_return_sync
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        if self._lock is not None:
-            self._lock.release()
+        pass
 
-    async def __async_unwrap(self):
-        if self._async_called:
-            await self._event.wait()
-        else:
-            self._async_called = True
-            self._event = Event()
-            try:
-                self._async_return = await self._sync_return
-            except Exception as e:
-                self._async_raise = True
-                self._async_return = e
-            self._event.set()
 
-        if self._async_raise:
-            raise self._async_return
+@dataclass(frozen=True)
+class _MemoAsync:
+    fn: InitVar[Fn]
+    expire_time: float
+    _memo_async_context: _MemoAsyncContext = field(init=False)
+
+    def __post_init__(self, fn: Fn) -> None:
+        object.__setattr__(self, '_memo_async_context', _MemoAsyncContext(fn=fn))
+
+    async def __call__(self, *args, **kwargs) -> Any:
+        async with self._memo_async_context as memo_async_return:
+            return await memo_async_return(*args, **kwargs)
+
+
+@dataclass(frozen=True)
+class _MemoSync:
+    fn: InitVar[Fn]
+    expire_time: float
+    _memo_sync_context: _MemoAsyncContext = field(init=False)
+
+    def __post_init__(self, fn: Fn) -> None:
+        object.__setattr__(self, '_memo_sync_context', _MemoSyncContext(fn=fn))
+
+    def __call__(self, *args, **kwargs) -> Any:
+        with self._memo_sync_context as memo_sync_return:
+            return memo_sync_return(*args, **kwargs)
+
+
+_Memo = Union[_MemoAsync, _MemoSync]
+
+
+class _MemoizeState:
+    def __init__(
+            self,
+            fn: Fn,
+            *,
+            size: Optional[int] = None,
+            duration: Optional[Union[int, timedelta]] = None,
+    ) -> None:
+        self._fn = fn
+        self._size = size
+        self._duration = duration.total_seconds() if isinstance(duration, timedelta) else duration
+
+        assert self._size is None or self._size > 0
+        assert self._duration is None or self._duration > 0
+
+        if self._duration is None:
+            self._expire_order = None
         else:
-            return self._async_return
+            self._expire_order = OrderedDict()
+        self._memos: OrderedDict = OrderedDict()
+        self._default_kwargs: OrderedDict = OrderedDict([
+            (k, v.default) for k, v in inspect.signature(self._fn).parameters.items()
+        ])
+
+    def __len__(self) -> int:
+        return len(self._memos)
+
+    def reset(self) -> None:
+        self._memos = OrderedDict()
+        self._expire_order = deque() if self._expire_order is not None else None
+
+    def make_key(self, *args, **kwargs) -> Tuple:
+        """Returns all params (args, kwargs, and missing default kwargs) for function as kwargs."""
+        args_as_kwargs = {}
+        for k, v in zip(self._default_kwargs, args):
+            args_as_kwargs[k] = v
+
+        return tuple(ChainMap(args_as_kwargs, kwargs, self._default_kwargs).values())
+
+    def get_memo(self, key, memo_type: Type[_Memo]) -> _Memo:
+        try:
+            memo = self._memos[key] = self._memos.pop(key)
+            if self._duration is not None and memo.expire_time < time():
+                self._expire_order.pop(key)
+                raise ValueError('value expired')
+        except (KeyError, ValueError):
+            if self._duration is None:
+                expire_time = None
+            else:
+                expire_time = time() + self._duration
+                self._expire_order[key] = ...
+
+            memo = self._memos[key] = memo_type(self._fn, expire_time=expire_time)
+
+        return memo
+
+    def expire_one_memo(self) -> None:
+        if self._expire_order is not None and \
+                len(self._expire_order) > 0 and \
+                self._memos[next(iter(self._expire_order))].expire_time < time():
+            self._memos.pop(self._expire_order.popitem(last=False)[0])
+        elif self._size is not None and self._size < len(self._memos):
+            self._memos.popitem(last=False)
+
+
+@dataclass
+class _MemoizeAsync:
+    fn: InitVar[Fn]
+    size: InitVar[Optional[int]] = None
+    duration: InitVar[Optional[Union[int, timedelta]]] = None
+    _state: _MemoizeState = field(init=False)
+    _lock_async: LockAsync = field(init=False, default_factory=lambda: LockAsync())
+
+    def __post_init__(
+            self, fn: Fn, size: Optional[int], duration: Optional[Union[int, timedelta]]
+    ) -> None:
+        self._state = _MemoizeState(fn=fn, size=size, duration=duration)
+
+    async def __call__(self, *args, **kwargs) -> Any:
+        key = self._state.make_key(*args, **kwargs)
+
+        async with self._lock_async:
+            memo = self._state.get_memo(key, memo_type=_MemoAsync)
+            self._state.expire_one_memo()
+
+        return await memo(*args, **kwargs)
+
+    def __len__(self) -> int:
+        return len(self._state)
+
+    def reset(self) -> None:
+        self._state.reset()
+
+
+memoize_async = type('memoize_async', (DecoratorMixin, _MemoizeAsync), {})
+
+
+@dataclass
+class _MemoizeSync:
+    fn: InitVar[Fn]
+    size: InitVar[Optional[int]] = None
+    duration: InitVar[Optional[Union[int, timedelta]]] = None
+    _state: _MemoizeState = field(init=False)
+    _lock_sync: LockSync = field(init=False, default_factory=lambda: LockSync())
+
+    def __post_init__(
+            self, fn: Fn, size: Optional[int], duration: Optional[Union[int, timedelta]]
+    ) -> None:
+        self._state = _MemoizeState(fn=fn, size=size, duration=duration)
+
+    def __call__(self, *args, **kwargs) -> Any:
+        key = self._state.make_key(*args, **kwargs)
+
+        with self._lock_sync:
+            memo = self._state.get_memo(key, memo_type=_MemoSync)
+            self._state.expire_one_memo()
+
+        return memo(*args, **kwargs)
+
+    def __len__(self) -> int:
+        return len(self._state)
+
+    def reset(self) -> None:
+        with self._lock_sync:
+            self._state.reset()
+
+
+memoize_sync = type('memoize_sync', (DecoratorMixin, _MemoizeSync), {})
 
 
 class _Memoize:
@@ -74,11 +258,6 @@ class _Memoize:
     If 'size' is provided, memoize will only retain up to 'size' return values.
 
     If 'expire' is provided, memoize will only retain return values for up to 'expire' duration.
-
-    If 'pass_unhashable' is True, memoize will not remember calls that are made with parameters
-      that cannot be hashed instead of raising an exception.
-
-    if 'thread_safe' is True, the decorator is guaranteed to be thread safe.
 
     Examples:
 
@@ -120,14 +299,6 @@ class _Memoize:
             sleep(61)
             foo(1)  # Function actually called. Previously-cached result was too old.
 
-        - Thread safety is not enabled by default. It must be explicitly enabled.
-            @memoize(thread_safe=True)
-            def foo(bar) -> Any: ...
-
-            # Concurrent calls from multiple threads are safe. Only one call is generated. The
-            # other nine calls in this example wait for the result.
-            concurrent.futures.Executor.map(foo, [1] * 10)
-
         - Memoize can be explicitly reset through the function's 'memoize' attribute
             @memoize
             def foo(bar) -> Any: ...
@@ -159,7 +330,7 @@ class _Memoize:
             b.bar  # Function actually called. Result cached.
             b.bar  # Function not called. Previously-cached result returned.
 
-        - Be careful with eviction on instance methods.
+        - Be careful with eviction on methods.
             Class Foo:
                 @memoize(size=1)
                 def foo(self): -> Any: ...
@@ -176,90 +347,20 @@ class _Memoize:
             *,
             size: Optional[int] = None,
             duration: Optional[Union[int, timedelta]] = None,
-            pass_unhashable: bool = False,
-            thread_safe: bool = False,
     ) -> None:
-
-        self._fn = fn
-        self._size = size
-        self._duration = duration.total_seconds() if isinstance(duration, timedelta) else duration
-        self._pass_unhashable = pass_unhashable
-        self._lock = Lock() if thread_safe else None
-
-        assert self._size is None or self._size > 0
-        assert self._duration is None or self._duration > 0
-
-        if self._duration is None:
-            self._expire_order = None
+        if inspect.iscoroutinefunction(fn):
+            self._memo = _MemoizeAsync(fn, size=size, duration=duration)
         else:
-            self._expire_order = OrderedDict()
-        self._memos: OrderedDict = OrderedDict()
-        self._default_kwargs: OrderedDict = OrderedDict([
-            (k, v.default) for k, v in inspect.signature(self._fn).parameters.items()
-        ])
+            self._memo = _MemoizeSync(fn, size=size, duration=duration)
 
     def __call__(self, *args, **kwargs) -> Any:
-        key = self._make_key(*args, **kwargs)
-
-        with self:
-            memo = self._get_memo(key)
-            self._expire_one_memo()
-
-        return memo(*args, **kwargs)
-
-    def __enter__(self) -> None:
-        if self._lock is not None:
-            self._lock.acquire()
-
-    def __exit__(self, exc_type, exc_val, exc_tb) -> None:
-        if self._lock is not None:
-            self._lock.release()
+        return self._memo(*args, **kwargs)
 
     def __len__(self) -> int:
-        with self:
-            return len(self._memos)
+        return len(self._memo)
 
     def reset(self) -> None:
-        with self:
-            self._memos = OrderedDict()
-            self._expire_order = deque() if self._expire_order is not None else None
-
-    def _make_key(self, *args, **kwargs) -> Tuple:
-        """Returns all params (args, kwargs, and missing default kwargs) for function as kwargs."""
-        args_as_kwargs = {}
-        for k, v in zip(self._default_kwargs, args):
-            args_as_kwargs[k] = v
-
-        return tuple(ChainMap(args_as_kwargs, kwargs, self._default_kwargs).values())
-
-    def _get_memo(self, key) -> _Memo:
-        try:
-            memo = self._memos[key] = self._memos.pop(key)
-            if self._duration is not None and memo.expire_time < time():
-                self._expire_order.pop(key)
-                raise ValueError('value expired')
-        except TypeError:
-            if not self._pass_unhashable:
-                raise
-            memo = _Memo(self._fn)
-        except (KeyError, ValueError):
-            if self._duration is None:
-                expire_time = None
-            else:
-                expire_time = time() + self._duration
-                self._expire_order[key] = ...
-            memo = self._memos[key] = _Memo(
-                self._fn, expire_time=expire_time, thread_safe=self._lock is not None)
-
-        return memo
-
-    def _expire_one_memo(self) -> None:
-        if self._expire_order is not None and \
-                len(self._expire_order) > 0 and \
-                self._memos[next(iter(self._expire_order))].expire_time < time():
-            self._memos.pop(self._expire_order.popitem(last=False)[0])
-        elif self._size is not None and self._size < len(self._memos):
-            self._memos.popitem(last=False)
+        return self._memo.reset()
 
 
 memoize = type('memoize', (DecoratorMixin, _Memoize), {})

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='atools',
-    version='0.3.1',
+    version='0.4.0',
     packages=['', 'atools'],
     python_requires='>=3.7',
     url='https://github.com/cevans87/atools',


### PR DESCRIPTION
No longer accepts 'thread_safe' or 'pass_unhashable' flags. No longer
automagically memoizes coroutine returns from sync functions (this kind of
behavior should be done explicitely anyway).