### PR TITLE
Resolves #33 - memoize db uses return type

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='atools',
-    version='0.10.2',
+    version='0.10.3',
     packages=find_packages(),
     python_requires='>=3.6',
     url='https://github.com/cevans87/atools',


### PR DESCRIPTION
Additionally, it can deserialze using any of the function's globals.