### PR TITLE
Attempt to warn developers if they accidentally use poorly hashable objects for their cache key

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,20 @@ Python 3.6+ decorators including
             @memoize(get_key=lambda a, b, c: (morph_a(a), b, c))
             def foo(a, b, c) -> Any: ...
 
+        - Be careful with memoize values that don't hash consistently within the same process
+          because object ID's get recycled 
+
+            class Foo:
+                @memoize
+                def bar(self) -> Any: ...
+            
+            Foo().bar()  # Function actually called. Result cached. Foo instance deleted.
+            
+            Foo().bar()  # Python uses same object id. Function not called. Previously-cached result returned.
+            
+            # The solution is to implement a custom `__hash__` function for your class,
+            # or a custom `get_key` function for your cache
+
         - Values can persist to disk and be reloaded when memoize is initialized again.
 
             @memoize(db=True)


### PR DESCRIPTION
There's a couple of known situations where `@memoize` will allow users to cache against a key that is not actually unique

An already documented example is that the hash value of a class changes across Python processes.

A new example I have found is that the hash value of an object (which in the default implementation depends on the [id()](https://docs.python.org/3/library/functions.html#id) function) might be reused once the original object is deleted. Because our cache doesn't get cleared on object deletion, this means that you will get a cache hit on the new object - even though the user probably is expecting a function call.

I'm not really sure how best to approach this, so this PR is a discussion starter. Short of actually solving the problem, for me it would be helpful to use a Python warning, and then I will notice that when I am testing. We probably don't want `@memoize` to raise an exception when it detects a potential problem, because that would probably break existing uses that aren't necessarily broken.