### PR TITLE
Use pickle to memoize to db

### DIFF
--- a/atools/_memoize_decorator.py
+++ b/atools/_memoize_decorator.py
@@ -6,11 +6,12 @@ from functools import partial, wraps
 from hashlib import sha256
 import inspect
 from pathlib import Path
+import pickle
 from sqlite3 import connect, Connection
 from textwrap import dedent
 from time import time
 from threading import Lock as SyncLock
-from typing import Any, Callable, Dict, Hashable, Mapping, Optional, Tuple, Type, Union
+from typing import Any, Callable, Hashable, Mapping, Optional, Tuple, Type, Union
 from weakref import finalize, WeakSet
 
 
@@ -58,22 +59,12 @@ class _MemoizeBase:
     keygen: Optional[Keygen]
     size: Optional[int]
 
-    db_eval_types: Optional[Dict[str, Any]] = field(init=False, default=None, hash=False)
     expire_order: OrderedDict = field(init=False, default_factory=OrderedDict, hash=False)
     memos: OrderedDict = field(init=False, default_factory=OrderedDict, hash=False)
 
     def __post_init__(self) -> None:
         if self.db is not None:
             self.db.isolation_level = None
-            return_annotation = inspect.signature(self.fn).return_annotation
-            if not hasattr(return_annotation, '__name__'):
-                object.__setattr__(self, 'db_eval_types', dict(self.fn.__globals__))
-            else:
-                object.__setattr__(
-                    self,
-                    'db_eval_types',
-                    {**self.fn.__globals__, return_annotation.__name__: return_annotation}
-                )
 
             self.db.execute(dedent(f'''
                 CREATE TABLE IF NOT EXISTS `{self.table_name}` (
@@ -101,7 +92,7 @@ class _MemoizeBase:
             ).fetchall():
                 memo = self.make_memo(fn=self.fn, t0=t0)
                 memo.memo_return_state.called = True
-                (memo.memo_return_state.value,) = eval(v, self.db_eval_types)
+                memo.memo_return_state.value = pickle.loads(v)
                 self.memos[k] = memo
             if self.duration:
                 for k, t0 in self.db.execute(
@@ -177,8 +168,7 @@ class _MemoizeBase:
             raise memo.memo_return_state.value
         else:
             if (self.db is not None) and (self.memos[key] is memo):
-                value = str((memo.memo_return_state.value,))
-                assert (memo.memo_return_state.value,) == eval(value, self.db_eval_types)
+                value = pickle.dumps(memo.memo_return_state.value)
                 self.db.execute(
                     dedent(f'''
                         INSERT OR REPLACE INTO `{self.table_name}`

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import find_packages, setup
 
 setup(
     name='atools',
-    version='0.10.6',
+    version='0.11.0',
     packages=find_packages(),
     python_requires='>=3.6',
     url='https://github.com/cevans87/atools',

--- a/test/test_memoize_decorator.py
+++ b/test/test_memoize_decorator.py
@@ -883,18 +883,6 @@ async def test_async_keygen_can_return_non_tuple() -> None:
     assert body.call_count == 1
 
 
-def test_db_can_return_type_of_return_hint(db: Union[bool, Connection, Path, str]) -> None:
-    class FooPath(PosixPath):
-        pass
-
-    @memoize(db=db)
-    def foo() -> FooPath:
-        return FooPath.cwd()
-
-    assert foo() == FooPath.cwd()
-    assert isinstance(foo(), FooPath)
-
-
 def test_db_can_return_type_of_callers_globals(db: Union[bool, Connection, Path, str]) -> None:
 
     @memoize(db=db)


### PR DESCRIPTION
Instead of using some complex `str()` and `eval()` logic to serialize
and deserialize python objects, we now use `pickle.{dumps|loads}`. The
pickle module does a good job of getting this right. Our previous logic
did not.

Resolve #45