### PR TITLE
Fix type annotation for _SyncMemo.sync_lock

### DIFF
--- a/atools/_memoize_decorator.py
+++ b/atools/_memoize_decorator.py
@@ -43,7 +43,7 @@ class _AsyncMemo(_MemoBase):
 
 @dataclass(frozen=True)
 class _SyncMemo(_MemoBase):
-    sync_lock: AsyncLock = field(init=False, default_factory=lambda: SyncLock())
+    sync_lock: SyncLock = field(init=False, default_factory=lambda: SyncLock())
 
 
 _Memo = Union[_AsyncMemo, _SyncMemo]


### PR DESCRIPTION
Hey @cevans87, I just saw this when I was in the code - i presume the type annotation is a mistake. Cheers!