### PR TITLE
Fix expire memo with size and duration

### DIFF
--- a/atools/_memoize_decorator.py
+++ b/atools/_memoize_decorator.py
@@ -174,6 +174,8 @@ class _MemoizeBase:
             self.memos.pop(k)
         elif self.size is not None and self.size < len(self.memos):
             (k, _) = self.memos.popitem(last=False)
+            if self.expire_order:
+                self.expire_order.pop(k)
         if (self.db is not None) and (k is not None):
             self.db.execute(f"DELETE FROM `{self.table_name}` WHERE k = '{k}'")
 

--- a/test/test_memoize_decorator.py
+++ b/test/test_memoize_decorator.py
@@ -162,6 +162,31 @@ async def test_async_size() -> None:
     body.assert_called_once_with(0)
 
 
+def test_sync_size_with_duration() -> None:
+    body = MagicMock()
+
+    @memoize(duration=timedelta(hours=1), size=1)
+    def foo(bar) -> None:
+        body(bar)
+
+    for i in range(3):
+        foo(i)
+    assert body.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_async_size_with_duration() -> None:
+    body = MagicMock()
+
+    @memoize(duration=timedelta(hours=1), size=1)
+    async def foo(bar) -> None:
+        body(bar)
+
+    for i in range(3):
+        await foo(i)
+    assert body.call_count == 3
+
+
 def test_sync_exception() -> None:
     class FooException(Exception):
         ...


### PR DESCRIPTION
Hi @cevans87 , we were getting `KeyError`s when both `duration` and `size` were specified with memoize.
I've included some tests to demonstrate the problem.