### PR TITLE
Fix version specifier for `dataclasses`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -7,7 +7,7 @@ long_description_content_type = text/markdown
 packages = 
 	atools
 install_requires =
-	dataclasses>="0.6";python_version=="3.6"
+	dataclasses>=0.6;python_version=="3.6"
 	frozendict
 py_modules = 
 	__init__


### PR DESCRIPTION
Fix installing `atools` with latest pip (23.1)

```
(venv) # pip --version
pip 23.1 from /tmp/venv/lib/python3.8/site-packages/pip (python 3.8)
(venv) # pip install atools
Collecting atools
  Downloading atools-0.14.1.tar.gz (14 kB)
  Installing build dependencies ... done
  Getting requirements to build wheel ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [50 lines of output]
      Traceback (most recent call last):
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/requirements.py", line 35, in __init__
          parsed = parse_requirement(requirement_string)
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/_parser.py", line 64, in parse_requirement
          return _parse_requirement(Tokenizer(source, rules=DEFAULT_RULES))
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/_parser.py", line 82, in _parse_requirement
          url, specifier, marker = _parse_requirement_details(tokenizer)
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/_parser.py", line 126, in _parse_requirement_details
          marker = _parse_requirement_marker(
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/_parser.py", line 147, in _parse_requirement_marker
          tokenizer.raise_syntax_error(
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/_tokenizer.py", line 163, in raise_syntax_error
          raise ParserSyntaxError(
      setuptools.extern.packaging._tokenizer.ParserSyntaxError: Expected end or semicolon (after name and no valid version specifier)
          dataclasses>="0.6";python_version=="3.6"
                     ^
      
      The above exception was the direct cause of the following exception:
      
      Traceback (most recent call last):
        File "/tmp/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/tmp/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
        File "/tmp/venv/lib/python3.8/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 338, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=['wheel'])
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 320, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 484, in run_setup
          super(_BuildMetaLegacyBackend,
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/build_meta.py", line 335, in run_setup
          exec(code, locals())
        File "<string>", line 3, in <module>
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 107, in setup
          _install_setup_requires(attrs)
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/__init__.py", line 78, in _install_setup_requires
          dist.parse_config_files(ignore_option_errors=True)
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 887, in parse_config_files
          self._finalize_requires()
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 594, in _finalize_requires
          self._move_install_requirements_markers()
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/dist.py", line 634, in _move_install_requirements_markers
          inst_reqs = list(_reqs.parse(spec_inst_reqs))
        File "/tmp/pip-build-env-vuhlf53v/overlay/lib/python3.8/site-packages/setuptools/_vendor/packaging/requirements.py", line 37, in __init__
          raise InvalidRequirement(str(e)) from e
      setuptools.extern.packaging.requirements.InvalidRequirement: Expected end or semicolon (after name and no valid version specifier)
          dataclasses>="0.6";python_version=="3.6"
                     ^
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build wheel did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
```